### PR TITLE
Fix Metapp filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,20 +71,21 @@ attribute can appear mostly everywhere syntax elements are enumerated,
 including tuples, function applications, arrays, etc.
 
 ```ocaml
-[%%meta Metapp.include_structure (
-  Metapp.filter.structure Metapp.filter [%str
-    type t =
+[%%metapackage metapp]
+[%%meta Metapp.Stri.of_list @@ (new Metapp.filter)#structure [%str
+  type t =
     | A of int
     | B of int * int
         [@if [%meta Metapp.Exp.of_bool (Sys.ocaml_version >= "4.04.0")]]
-    ...
+    (* ... *)
 
+  let somefunction v =
     match (v: t) with
     | A x -> something x
     | B (y,z)
       [@if [%meta Metapp.Exp.of_bool (Sys.ocaml_version >= "4.04.0")]] ->
         something' y z
-    ... ])]
+    (* ... *) ]]
 ```
 
 Global definitions for meta-code can be included with `[%%metadef

--- a/tests/utils/test_utils.ml
+++ b/tests/utils/test_utils.ml
@@ -11,6 +11,41 @@ let () =
 [%%meta (new Metapp.filter)#structure_item
   [%stri let a = 1 and[@if false] b = c]]
 
+type other = AX | CX
+
+[%%meta (new Metapp.filter)#structure_item
+  [%stri type test = other =  AX | BX [@if false] | CX]
+]
+
+type other2 = { a: int; b: float }
+
+[%%meta (new Metapp.filter)#structure_item
+  [%stri type test2 = other2 = { a: int; b: float; c: bool [@if false]}]
+]
+
+let make2 x =
+  [%meta (new Metapp.filter)#expression [%e
+    { a = 4; b = 5.0; c = 4 [@if false] }
+  ]]
+
+let something' _ _ = ()
+let something _ = ()
+
+[%%meta Metapp.Stri.of_list @@ (new Metapp.filter)#structure [%str
+  type t =
+    | A of int
+    | B of int * int
+        [@if [%meta Metapp.Exp.of_bool (Sys.ocaml_version >= "4.04.0")]]
+    (* ... *)
+
+  let somefunction v =
+    match (v: t) with
+    | A x -> something x
+    | B (y,z)
+      [@if [%meta Metapp.Exp.of_bool (Sys.ocaml_version >= "4.04.0")]] ->
+        something' y z
+    (* ... *) ]]
+
 let () =
   Test_framework.assert_eq Int.equal Format.pp_print_int a 1
 


### PR DESCRIPTION
The syntax seems to have changed, and `Metapp.filter.structure` mentioned in the README doesn't exist anymore.

Filtering for type declarations was also missing. Implement it and add a testcase.

I've tested this only on very simple examples so far.